### PR TITLE
Added instruction to run bin/vendors install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Installation
     git=http://github.com/symfony/DoctrineFixturesBundle.git
     target=/bundles/Symfony/Bundle/DoctrineFixturesBundle
 ```
+Next, run the vendors script to download the bundles:
+
+``` bash
+$ php bin/vendors install
+```
 
 ### Add to autoload.php
 


### PR DESCRIPTION
Simply adding to deps isn't enough to get the bundles instaalled, of course we also need to run php bin/vendors install. Made this change to the readme.
