### PR TITLE
Fixed remove link so that it works correctly to remove row now.

### DIFF
--- a/Resources/views/Order/index.html.twig
+++ b/Resources/views/Order/index.html.twig
@@ -72,6 +72,9 @@
         if ($(this).text() === "Add") {
             add();
         }
+        if ($(this).text() === "Remove") {
+            $(this).closest('tr').remove();
+        }
         event.preventDefault();
     });
 


### PR DESCRIPTION
Remove link wasn't working. At first I thought this had something to do with Symfony, but after looking at template I realized it was nothing of the sort and we were just missing a little jQuery. Added a couple of lines and now you can remove a pizza from your order you're building.
